### PR TITLE
[FE-017] 학생용, 선생님용 회원가입 분할

### DIFF
--- a/FrontEnd/src/App.js
+++ b/FrontEnd/src/App.js
@@ -18,11 +18,11 @@ function App() {
       <Header />
       <Switch>
         <Route path="/" render={() => <IntroPage />} exact />
-        <Route path="/main" render={() => <MainPage />} exact />
-        <Route path="/login" render={() => <LoginPage />} exact />
-        <Route path="/signup" render={() => <SignupPage />} exact />
-        <Route path="/test" render={() => <TestPage />} exact />
-        <Route path="/teacher" render={() => <TeacherPage />} exact />
+        <Route path="/main" render={() => <MainPage />} />
+        <Route path="/login" render={() => <LoginPage />} />
+        <Route path="/signup" render={() => <SignupPage />} />
+        <Route path="/test" render={() => <TestPage />} />
+        <Route path="/teacher" render={() => <TeacherPage />} />
         <Route component={NotFoundPage} />
       </Switch>
       <Footer />

--- a/FrontEnd/src/assets/css/default.css
+++ b/FrontEnd/src/assets/css/default.css
@@ -1,6 +1,7 @@
 /* default style setting */
 :root {
-  --black : #222;
+	--black : #222;
+	--gray: #ccc;
 	--white: #fff;
 	--red: crimson;
 }

--- a/FrontEnd/src/components/Login/SelectSignupType.css
+++ b/FrontEnd/src/components/Login/SelectSignupType.css
@@ -55,9 +55,18 @@
     width: 95%;
   }
 
+  .select-signup-wrapper h2 {
+    font-size: 1.2em;
+  }
+
   .signup-button-group a {
     display: flex;
     justify-content: space-between;
+  }
+
+  .signup-button-group a i.fas {
+    font-size: 2.5em;
+    padding-right: 0;
   }
 
   .signup-button-group a p span {

--- a/FrontEnd/src/components/Login/SelectSignupType.css
+++ b/FrontEnd/src/components/Login/SelectSignupType.css
@@ -1,0 +1,66 @@
+.select-signup-wrapper {
+  margin: 2rem auto;
+  width: 80%;
+  min-width: 300px;
+}
+
+.select-signup-wrapper h2 {
+  margin-bottom: 1em;
+  text-align: center;
+}
+
+.signup-button-group {
+  text-align: center;
+}
+
+.signup-button-group a {
+  display: inline-flex;
+  align-items: center;
+  padding: 1em 2.5em;
+  margin: 0.4em;
+  border-radius: 0.75rem;
+  font-weight: 600;
+  transition: all .2s;
+}
+
+.signup-button-group a:first-child {
+  background-color: mediumaquamarine;
+  color: var(--black);
+}
+
+.signup-button-group a:last-child {
+  background-color: midnightblue;
+  color: var(--white);
+}
+
+.signup-button-group a i.fas {
+  font-size: 3em;
+  padding-right: 0.4em;
+}
+
+.signup-button-group a p {
+  line-height: 1.4;
+}
+
+.signup-button-group a p span {
+  display: block;
+}
+
+.signup-button-group a:hover {
+  box-shadow: 3px 3px 5px rgba(0, 0, 0, .2);
+}
+
+@media screen and (max-width: 600px) {
+  .select-signup-wrapper {
+    width: 95%;
+  }
+
+  .signup-button-group a {
+    display: flex;
+    justify-content: space-between;
+  }
+
+  .signup-button-group a p span {
+    display: inline;
+  }
+}

--- a/FrontEnd/src/components/Login/SelectSignupType.js
+++ b/FrontEnd/src/components/Login/SelectSignupType.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import './SelectSignupType.css';
+
+const SelectSignupType = () => {
+  return (
+    <div className="select-signup-wrapper">
+      <h2>가입할 계정의 유형을 선택해주세요.</h2>
+      <div className="signup-button-group">
+        <Link to="/signup?type=student">
+          <i className="fas fa-user" />
+          <p><span>학생 계정</span> <span>회원가입</span></p>
+        </Link>
+        <Link to="/signup?type=teacher">
+          <i className="fas fa-chalkboard-teacher" />
+          <p><span>선생님 계정</span> <span>회원가입</span></p>
+        </Link>
+      </div>
+    </div>
+  );
+};
+
+export default SelectSignupType;

--- a/FrontEnd/src/components/Login/Signup.css
+++ b/FrontEnd/src/components/Login/Signup.css
@@ -1,0 +1,65 @@
+.signup-form {
+  margin: 2rem auto;
+  width: 80%;
+  min-width: 300px;
+}
+
+.signup-form h2 {
+  margin-bottom: 1em;
+  text-align: center;
+}
+
+.signup-form form {
+  margin: 0 auto;
+  max-width: 600px;
+}
+
+.signup-form article {
+  display: flex;
+  align-items: center;
+  width: 100%;
+}
+
+.signup-form article label {
+  font-weight: 600;
+  padding-right: 0.5em;
+}
+
+.signup-form article input {
+  flex-grow: 1;
+}
+
+.signup-form small {
+  display: block;
+  margin: 0.3em 0 1.2em;
+  color: var(--red);
+}
+
+.signup-form button {
+  display: block;
+  width: 100%;
+  background-color: var(--gray);
+  font-weight: 600;
+  padding: 0.5em 0;
+}
+
+@media screen and (max-width: 600px) {
+  .signup-form {
+    width: 95%;
+  }
+
+  .signup-form article {
+    display: block;
+  }
+
+  .signup-form label {
+    display: inline-block;
+    padding-bottom: 0.1em;
+    margin-bottom: 0.6em;
+    border-bottom: 1px solid var(--gray);
+  }
+
+  .signup-form input {
+    width: 100%;
+  }
+}

--- a/FrontEnd/src/components/Login/Signup.js
+++ b/FrontEnd/src/components/Login/Signup.js
@@ -1,11 +1,85 @@
-import React from 'react';
+import React, { useState, useCallback, memo } from 'react';
+import { withRouter } from 'react-router-dom';
+import validation from '../../util/validation';
+import './Signup.css';
 
-const Signup = () => {
+const signupFormTitle = signupType => `${signupType === 'student' ? '학생용' : '선생님용'} 계정 회원가입`;
+
+const Signup = memo(({ signupType, history }) => {
+  const [id, setId] = useState('');
+  const [password, setPassword] = useState('');
+  const [username, setUsername] = useState('');
+  const [email, setEmail] = useState('');
+
+  const onChangeId = useCallback(e => {
+    setId(e.target.value);
+  }, []);
+
+  const onChangePassword = useCallback(e => {
+    setPassword(e.target.value);
+  }, []);
+
+  const onChangeUsername = useCallback(e => {
+    setUsername(e.target.value);
+  }, []);
+
+  const onChangeEmail = useCallback(e => {
+    setEmail(e.target.value);
+  }, []);
+
+  const onSubmitSignup = e => {
+    e.preventDefault();
+    if (id.length === 0 && password.length === 0 && username.length === 0 && email.length === 0) {
+      alert('회원가입 양식을 모두 작성해주세요.');
+      return
+    }
+    if (!validation.idValidation(id)) {
+      alert('최소 조건에 맞게 아이디를 다시 작성해주세요.');
+      return
+    }
+    if (!validation.passwordValidation(password)) {
+      alert('최소 조건에 맞게 비밀번호를 다시 작성해주세요.');
+      return
+    }
+    if (!validation.usernameValidation(username)) {
+      alert('한글 이름을 다시 작성해주세요.');
+      return
+    }
+    if (!validation.emailValidation(email)) {
+      alert('이메일 양식을 지켜서 다시 작성해주세요.');
+      return
+    }
+    history.push('/main');
+  }
+
   return (
-    <div>
-      
+    <div className="signup-form">
+      <h2>{ signupFormTitle(signupType) }</h2>
+      <form onSubmit={onSubmitSignup} >
+        <article className="input-id">
+          <label htmlFor="id" name="id">아이디</label>
+          <input type="text" id="id" value={id} onChange={onChangeId} />
+        </article>
+        <small>(아이디는 영어 소문자 4자 이상, 숫자 2자 이상으로 만들어주세요.)</small>
+        <article className="input-password">
+          <label htmlFor="password" name="password">비밀번호</label>
+          <input type="password" id="password" value={password} onChange={onChangePassword} />
+        </article>
+        <small>(비밀번호는 영어 소문자 6자 이상, 숫자 4자 이상으로 만들어주세요.)</small>
+        <article className="input-username">
+          <label htmlFor="username" name="username">이름</label>
+          <input type="text" id="username" value={username} onChange={onChangeUsername} />
+        </article>
+        <small>(가입하시는 분의 한글 이름을 작성해주세요.)</small>
+        <article className="input-email">
+          <label htmlFor="email" name="email">이메일</label>
+          <input type="email" id="email" value={email} onChange={onChangeEmail} />
+        </article>
+        <small>(이메일 양식을 지켜서 작성해주세요.)</small>
+        <button type="submit">회원가입</button>
+      </form>
     </div>
   );
-};
+});
 
-export default Signup;
+export default withRouter(Signup);

--- a/FrontEnd/src/components/Login/Signup.js
+++ b/FrontEnd/src/components/Login/Signup.js
@@ -1,33 +1,33 @@
-import React, { useState, useCallback, memo } from 'react';
+import React, { memo, useReducer, useMemo } from 'react';
 import { withRouter } from 'react-router-dom';
 import validation from '../../util/validation';
 import './Signup.css';
 
-const signupFormTitle = signupType => `${signupType === 'student' ? '학생용' : '선생님용'} 계정 회원가입`;
+const reducer = (state, action) => {
+  return {
+    ...state,
+    [action.id]: action.value
+  };
+}
+
+const signupTitle = signupType => `${signupType === 'student' ? '학생용' : '선생님용'} 계정 회원가입`;
 
 const Signup = memo(({ signupType, history }) => {
-  const [id, setId] = useState('');
-  const [password, setPassword] = useState('');
-  const [username, setUsername] = useState('');
-  const [email, setEmail] = useState('');
+  const signupFormTitle = useMemo(() => signupTitle(signupType), [signupType]);
+  const [state, dispatch] = useReducer(reducer, {
+    id: '',
+    password: '',
+    username: '',
+    email: ''
+  });
 
-  const onChangeId = useCallback(e => {
-    setId(e.target.value);
-  }, []);
+  const { id, password, username, email } = state;
 
-  const onChangePassword = useCallback(e => {
-    setPassword(e.target.value);
-  }, []);
+  const onChange = e => {
+    dispatch(e.target);
+  }
 
-  const onChangeUsername = useCallback(e => {
-    setUsername(e.target.value);
-  }, []);
-
-  const onChangeEmail = useCallback(e => {
-    setEmail(e.target.value);
-  }, []);
-
-  const onSubmitSignup = e => {
+  const onSubmit = e => {
     e.preventDefault();
     if (id.length === 0 && password.length === 0 && username.length === 0 && email.length === 0) {
       alert('회원가입 양식을 모두 작성해주세요.');
@@ -49,31 +49,34 @@ const Signup = memo(({ signupType, history }) => {
       alert('이메일 양식을 지켜서 다시 작성해주세요.');
       return
     }
+
+    // 추후 이 부분에 state 값을 백엔드로 보내는 회원가입 로직 작성
+
     history.push('/main');
   }
 
   return (
     <div className="signup-form">
-      <h2>{ signupFormTitle(signupType) }</h2>
-      <form onSubmit={onSubmitSignup} >
+      <h2>{ signupFormTitle }</h2>
+      <form onSubmit={onSubmit}>
         <article className="input-id">
           <label htmlFor="id" name="id">아이디</label>
-          <input type="text" id="id" value={id} onChange={onChangeId} />
+          <input type="text" id="id" value={id} onChange={onChange} />
         </article>
         <small>(아이디는 영어 소문자 4자 이상, 숫자 2자 이상으로 만들어주세요.)</small>
         <article className="input-password">
           <label htmlFor="password" name="password">비밀번호</label>
-          <input type="password" id="password" value={password} onChange={onChangePassword} />
+          <input type="password" id="password" value={password} onChange={onChange} />
         </article>
         <small>(비밀번호는 영어 소문자 6자 이상, 숫자 4자 이상으로 만들어주세요.)</small>
         <article className="input-username">
           <label htmlFor="username" name="username">이름</label>
-          <input type="text" id="username" value={username} onChange={onChangeUsername} />
+          <input type="text" id="username" value={username} onChange={onChange} />
         </article>
         <small>(가입하시는 분의 한글 이름을 작성해주세요.)</small>
         <article className="input-email">
           <label htmlFor="email" name="email">이메일</label>
-          <input type="email" id="email" value={email} onChange={onChangeEmail} />
+          <input type="email" id="email" value={email} onChange={onChange} />
         </article>
         <small>(이메일 양식을 지켜서 작성해주세요.)</small>
         <button type="submit">회원가입</button>

--- a/FrontEnd/src/pages/NotFoundPage.js
+++ b/FrontEnd/src/pages/NotFoundPage.js
@@ -16,7 +16,7 @@ const exclamationMarkStyle = {
 const NotFound = () => {
   return (
     <div style={notFoundPageStyle}>
-      <i class="fas fa-exclamation-triangle" style={exclamationMarkStyle} />
+      <i className="fas fa-exclamation-triangle" style={exclamationMarkStyle} />
       <h3><b>이 페이지는 없는 페이지 입니다.</b></h3>
       <Link to="/">메인으로</Link>
     </div>

--- a/FrontEnd/src/pages/SignupPage.js
+++ b/FrontEnd/src/pages/SignupPage.js
@@ -1,11 +1,15 @@
 import React from 'react';
+import { withRouter } from 'react-router-dom';
+import Signup from '../components/Login/Signup';
+import SelectSignupType from '../components/Login/SelectSignupType';
 
-const SignupPage = () => {
+const SignupPage = ({ location }) => {
+  const query = new URLSearchParams(location.search);
+  const signupType = query.get('type');
+
   return (
-    <div>
-      Signup Page
-    </div>
+    signupType ? <Signup signupType={signupType} /> : <SelectSignupType />
   );
 };
 
-export default SignupPage;
+export default withRouter(SignupPage);

--- a/FrontEnd/src/util/validation.js
+++ b/FrontEnd/src/util/validation.js
@@ -1,0 +1,24 @@
+let emailReg = /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
+let alphabetReg = /[a-zA-Z]/g;
+let alphabetLowerCaseReg = /[a-z]/g;
+let numberReg = /[0-9]/g;
+let koreanReg = /[가-힣]/g;
+let koreanConsonantVowelReg = /[ㄱ-ㅎ|ㅏ-ㅣ]/g;
+let specialMarkReg = /[~!@#$%^&*()_+|<>?:{}]/g;
+
+const validation = {
+  idValidation: id => {
+    return id.match(alphabetLowerCaseReg).length >= 4 && id.match(numberReg).length >= 2;
+  },
+  passwordValidation: password => {
+    return password.match(alphabetLowerCaseReg).length >= 6 && password.match(numberReg).length >= 4;
+  },
+  usernameValidation: username => {
+    return koreanReg.test(username) && !numberReg.test(username) && !alphabetReg.test(username) && !specialMarkReg.test(username) && !koreanConsonantVowelReg.test(username);
+  },
+  emailValidation: email => {
+    return emailReg.test(String(email).toLowerCase());
+  }
+}
+
+export default validation;


### PR DESCRIPTION
## Online Test Pull Request

## 규칙
* 리뷰어 전원의 approve가 필요합니다.
* 마지막 approve한 리뷰어가 merge 후 해당 브랜치를 삭제합니다.

<!-- 본인이 올린 PR에 대한 내용을 달아주세요 -->
## 내용
**1. `SignupPage` 구성**
- query parameter를 탐색해서 없는 경우 학생용 또는 선생님용 회원가입 버튼 컴포넌트가 나타나고 있는 경우 해당 type에 맞게 회원가입 양식 나오도록 구성

**2. `Signup` component 구성**
- 학생용 또는 선생님용 회원 가입 기본 양식 구성
- 추후 선생님용 회원 가입 양식에 추가로 들어갈 내용 구성할 예정

**3. `validation` 함수 추가**
- `util` 폴더 안에 `validation` 함수 추가
- 이메일 양식, 한글, 영어, 숫자 등 정규 표현식을 이용해서 입력된 값을 검증할 수 있도록 구성

**4. `useReducer` hook 적용(2020-09-04 Update)**
- state를 따로따로 관리했던 방식에서 `useReducer` hook을 사용해서 하나의 hook 사용으로 관리할 수 있도록 구조 개선
- React의 `불변성 유지` 철학을 지키기 위해 Javascript의 <u>계산된 속성명</u>을 이용해서 변화하는 값에 대해서만 바뀔 수 있도록 `reducer`를 구성

**5. 회원가입 양식 제목에 `useMemo` hook 적용(2020-09-04 Update)**
- `input` 창에 값을 입력할 때마다 회원가입 양식 제목 부분이 계산 렌더링되는 문제점을 발견
- 처음 페이지가 열렸을 때만 렌더링 되도록 `useMemo`를 사용해서 개선

<!-- PR을 올리며 아쉬운 부분이나 리뷰어의 
    도움이 필요한 부분을 남겨주세요 -->
## 의견
- ~ 한 부분 퍼포먼스가 좋지않을듯한데 더 좋은 코드가 있을까요?
    
<details><summary>리뷰어 도움말</summary>
<p>

> 리뷰 코멘트시 다음의 말머리를 사용해 주세요.
#### 머지 OK
  - [의견] - 더 나은 것으로 생각되는 코드가 있는 경우 제안
  - [질문] - 설명이 부족하거나 이 부분만으로는 이유를 알 수 없는 부분에 설명을 부탁
</p>
</details>