### PR TITLE
[FE-015] 로그인 페이지, 비밀번호 찾기 레이아웃 구성

### DIFF
--- a/FrontEnd/src/assets/css/default.css
+++ b/FrontEnd/src/assets/css/default.css
@@ -70,4 +70,6 @@ button {
 	background: transparent;
 	cursor: pointer;
 	color: var(--black);
+	font-size: 1em;
+	font-family: 'Gothic A1';
 }

--- a/FrontEnd/src/components/Login/FindPassword.css
+++ b/FrontEnd/src/components/Login/FindPassword.css
@@ -1,0 +1,92 @@
+.find-password-form {
+  margin: 2rem auto;
+  width: 80%;
+  min-width: 300px;
+}
+
+.find-password-form h2 {
+  margin-bottom: 1em;
+  text-align: center;
+}
+
+.find-password-form form {
+  margin: 0 auto 1.5em;
+  max-width: 600px;
+}
+
+.find-password-form article {
+  display: flex;
+  align-items: center;
+  margin: 0.3em 0 1.2em;
+  width: 100%;
+}
+
+.find-password-form article label {
+  font-weight: 600;
+  padding-right: 0.5em;
+}
+
+.find-password-form article input {
+  flex-grow: 1;
+}
+
+small.email-message {
+  display: block;
+  font-weight: 600;
+  margin-bottom: 1.2em;
+}
+
+article.button-wrapper {
+  display: block;
+}
+
+.button-wrapper > .temp-password-alert {
+  display: flex;
+  align-items: center;
+  border: 1px solid var(--gray);
+  color: var(--red);
+  padding: 0.5em;
+}
+
+.button-wrapper .temp-password-alert > i {
+  font-size: 2em;
+  padding-right: 0.5em;
+}
+
+.button-wrapper p {
+  line-height: 1.5;
+}
+
+.button-wrapper button {
+  display: block;
+  width: 100%;
+  background-color: var(--gray);
+  font-weight: 600;
+  padding: 0.5em 0;
+  margin-bottom: 1.5em;
+}
+
+@media screen and (max-width: 600px) {
+  .find-password-form {
+    width: 95%;
+  }
+
+  .find-password-form article {
+    display: block;
+  }
+
+  .find-password-form label {
+    display: inline-block;
+    padding-bottom: 0.1em;
+    margin-bottom: 0.6em;
+    border-bottom: 1px solid var(--gray);
+  }
+
+  .find-password-form input {
+    width: 100%;
+  }
+
+  .button-wrapper p {
+    font-size: 0.9em;
+  }
+}

--- a/FrontEnd/src/components/Login/FindPassword.js
+++ b/FrontEnd/src/components/Login/FindPassword.js
@@ -1,13 +1,7 @@
-import React, { useReducer, useCallback } from 'react';
+import React, { useReducer } from 'react';
 import { withRouter } from 'react-router-dom';
+import { reducer } from '../../util/reducer';
 import './FindPassword.css';
-
-const reducer = (state, action) => {
-  return {
-    ...state,
-    [action.id]: action.value
-  };
-}
 
 const FindPassword = ({ history }) => {
   const [state, dispatch] = useReducer(reducer, {
@@ -17,9 +11,9 @@ const FindPassword = ({ history }) => {
 
   const { id, email } = state;
 
-  const onChange = useCallback(e => {
+  const onChange = e => {
     dispatch(e.target);
-  }, []);
+  };
 
   const onSubmit = e => {
     e.preventDefault();

--- a/FrontEnd/src/components/Login/FindPassword.js
+++ b/FrontEnd/src/components/Login/FindPassword.js
@@ -1,0 +1,69 @@
+import React, { useReducer, useCallback } from 'react';
+import { withRouter } from 'react-router-dom';
+import './FindPassword.css';
+
+const reducer = (state, action) => {
+  return {
+    ...state,
+    [action.id]: action.value
+  };
+}
+
+const FindPassword = ({ history }) => {
+  const [state, dispatch] = useReducer(reducer, {
+    id: '',
+    email: ''
+  });
+
+  const { id, email } = state;
+
+  const onChange = useCallback(e => {
+    dispatch(e.target);
+  }, []);
+
+  const onSubmit = e => {
+    e.preventDefault();
+    if (id.length === 0) {
+      alert('아이디를 입력해주세요.');
+      return
+    }
+    if (email.length === 0) {
+      alert('이메일을 입력해주세요.');
+      return
+    }
+
+    // 추후 state 값을 백엔드로 보내서 입력한 이메일로 임시 비밀번호 보내는 로직 구현
+
+    alert(`${email} 으로 임시 비밀번호를 보냈습니다.\n임시 비밀번호로 다시 로그인해주세요.`);
+    history.push('/login');
+  };
+
+  return (
+    <div className="find-password-form">
+      <h2>비밀번호 찾기</h2>
+      <form onSubmit={onSubmit}>
+        <article className="input-id">
+          <label htmlFor="id" name="id">아이디</label>
+          <input type="text" id="id" value={id} onChange={onChange} />
+        </article>
+        <article className="input-email">
+          <label htmlFor="email" name="email">이메일</label>
+          <input type="email" id="email" value={email} onChange={onChange} />
+        </article>
+        <small className="email-message">(회원가입시 작성했던 이메일을 입력해주세요.)</small>
+        <article className="button-wrapper">
+          <div className="temp-password-alert">
+            <i className="fas fa-exclamation-circle" />
+            <p>
+              작성하신 이메일 주소로 임시 비밀번호를 보내드립니다.<br/>
+              로그인 후 회원정보 수정에서 비밀번호를 꼭 변경해주세요!
+            </p>
+          </div>
+          <button type="submit"><i className="fas fa-key" /> 비밀번호 찾기</button>
+        </article>
+      </form>
+    </div>
+  );
+};
+
+export default withRouter(FindPassword);

--- a/FrontEnd/src/components/Login/Login.css
+++ b/FrontEnd/src/components/Login/Login.css
@@ -1,0 +1,71 @@
+.login-form {
+  margin: 2rem auto;
+  width: 80%;
+  min-width: 300px;
+}
+
+.login-form h2 {
+  margin-bottom: 1em;
+  text-align: center;
+}
+
+.login-form form {
+  margin: 0 auto 1.5em;
+  max-width: 600px;
+}
+
+.login-form article {
+  display: flex;
+  align-items: center;
+  margin: 0.3em 0 1.2em;
+  width: 100%;
+}
+
+.login-form article label {
+  font-weight: 600;
+  padding-right: 0.5em;
+}
+
+.login-form article input:not(#save-id) {
+  flex-grow: 1;
+}
+
+.login-form button {
+  display: block;
+  width: 100%;
+  background-color: var(--gray);
+  font-weight: 600;
+  padding: 0.5em 0;
+  margin-bottom: 1.5em;
+}
+
+.login-form .find-password-link {
+  display: block;
+  margin: 0 auto;
+  max-width: 600px;
+  text-align: center;
+  background-color: var(--gray);
+  font-weight: 600;
+  padding: 0.5em 0;
+}
+
+@media screen and (max-width: 600px) {
+  .login-form {
+    width: 95%;
+  }
+
+  .login-form article {
+    display: block;
+  }
+
+  .login-form label {
+    display: inline-block;
+    padding-bottom: 0.1em;
+    margin-bottom: 0.6em;
+    border-bottom: 1px solid var(--gray);
+  }
+
+  .login-form input:not(#save-id) {
+    width: 100%;
+  }
+}

--- a/FrontEnd/src/components/Login/Login.js
+++ b/FrontEnd/src/components/Login/Login.js
@@ -1,14 +1,8 @@
 import React, { useReducer, useState, useEffect, useRef, useCallback } from 'react';
 import { withRouter, Link } from 'react-router-dom';
 import { storage } from '../../util/storage';
+import { reducer } from '../../util/reducer';
 import './Login.css';
-
-const reducer = (state, action) => {
-  return {
-    ...state,
-    [action.id]: action.value
-  };
-}
 
 const Login = ({ history }) => {
   const [isSaveId, setIsSaveId] = useState(false);
@@ -36,9 +30,9 @@ const Login = ({ history }) => {
     }
   }, []);
   
-  const onChange = useCallback(e => {
+  const onChange = e => {
     dispatch(e.target);
-  }, []);
+  };
   
   const onChangeIsSaveId = useCallback(e => {
     setIsSaveId(e.target.checked);

--- a/FrontEnd/src/components/Login/Login.js
+++ b/FrontEnd/src/components/Login/Login.js
@@ -1,19 +1,98 @@
-import React, { useState, useCallback } from 'react';
+import React, { useReducer, useState, useEffect, useRef, useCallback } from 'react';
+import { withRouter, Link } from 'react-router-dom';
+import { storage } from '../../util/storage';
 import './Login.css';
 
-const Login = () => {
-  const [userName, setUserName] = useState('');
+const reducer = (state, action) => {
+  return {
+    ...state,
+    [action.id]: action.value
+  };
+}
+
+const Login = ({ history }) => {
+  const [isSaveId, setIsSaveId] = useState(false);
+  const checkBoxEl = useRef(null);
+
+  const [state, dispatch] = useReducer(reducer, {
+    id: '',
+    password: ''
+  });
+
+  const { id, password } = state;
+
+  useEffect(() => {
+    const saveId = storage(localStorage).getItem('saveId');
+    if (saveId) {
+      checkBoxEl.current.checked = true;
+      setIsSaveId(true);
+      dispatch({
+        id: 'id',
+        value: saveId
+      })
+    } else {
+      checkBoxEl.current.checked = false;
+      setIsSaveId(false);
+    }
+  }, []);
   
-  const onClick = useCallback(() => {
-    setUserName('new name');
+  const onChange = useCallback(e => {
+    dispatch(e.target);
+  }, []);
+  
+  const onChangeIsSaveId = useCallback(e => {
+    setIsSaveId(e.target.checked);
   }, []);
 
+  const onSubmit = e => {
+    e.preventDefault();
+    if (id.length === 0) {
+      alert('아이디를 입력해주세요.');
+      return
+    }
+    if (password.length === 0) {
+      alert('비밀번호를 입력해주세요.');
+      return
+    }
+
+    // 아이디 저장 로직
+    if (isSaveId) {
+      storage(localStorage).setItem('saveId', id);
+    } else {
+      storage(localStorage).removeItem('saveId');
+    }
+
+    // 추후 이 부분에 state 값을 백엔드로 보내는 로그인 로직 작성
+
+    history.push('/main');
+  };
+
   return (
-    <div>
-      {userName}
-      <button onClick={onClick}>Show</button>
+    <div className="login-form">
+      <h2>로그인</h2>
+      <form onSubmit={onSubmit}>
+        <article className="input-id">
+          <label htmlFor="id" name="id">아이디</label>
+          <input type="text" id="id" value={id} onChange={onChange} />
+        </article>
+        <article className="input-password">
+          <label htmlFor="password" name="password">비밀번호</label>
+          <input type="password" id="password" value={password} onChange={onChange} />
+        </article>
+        <article className="save-id">
+          <label htmlFor="save-id" name="save-id">아이디 저장</label>
+          <input ref={checkBoxEl} type="checkbox" id="save-id" value={isSaveId} onChange={onChangeIsSaveId}/>
+        </article>
+        <button type="submit"><i className="fas fa-sign-in-alt" /> 로그인</button>
+        <Link
+          to="login/findpassword"
+          className="find-password-link"
+        >
+          <i className="fas fa-key" /> 비밀번호 찾기
+        </Link>
+      </form>
     </div>
   );
 };
 
-export default Login;
+export default withRouter(Login);

--- a/FrontEnd/src/components/Login/Signup.js
+++ b/FrontEnd/src/components/Login/Signup.js
@@ -79,7 +79,7 @@ const Signup = memo(({ signupType, history }) => {
           <input type="email" id="email" value={email} onChange={onChange} />
         </article>
         <small>(이메일 양식을 지켜서 작성해주세요.)</small>
-        <button type="submit">회원가입</button>
+        <button type="submit"><i className="fas fa-user-plus" /> 회원가입</button>
       </form>
     </div>
   );

--- a/FrontEnd/src/components/Login/Signup.js
+++ b/FrontEnd/src/components/Login/Signup.js
@@ -1,14 +1,8 @@
 import React, { memo, useReducer, useMemo } from 'react';
 import { withRouter } from 'react-router-dom';
 import validation from '../../util/validation';
+import { reducer } from '../../util/reducer';
 import './Signup.css';
-
-const reducer = (state, action) => {
-  return {
-    ...state,
-    [action.id]: action.value
-  };
-}
 
 const signupTitle = signupType => `${signupType === 'student' ? '학생용' : '선생님용'} 계정 회원가입`;
 

--- a/FrontEnd/src/pages/LoginPage.js
+++ b/FrontEnd/src/pages/LoginPage.js
@@ -1,11 +1,14 @@
 import React from 'react';
+import { withRouter } from 'react-router-dom';
+import Login from '../components/Login/Login';
+import FindPassword from '../components/Login/FindPassword';
 
-const LoginPage = () => {
+const LoginPage = ({ location }) => {
+  const { pathname } = location;
+
   return (
-    <div>
-      Login Page
-    </div>
+    pathname === '/login' ? <Login /> : <FindPassword />
   );
 };
 
-export default LoginPage;
+export default withRouter(LoginPage);

--- a/FrontEnd/src/util/reducer.js
+++ b/FrontEnd/src/util/reducer.js
@@ -1,0 +1,6 @@
+export const reducer = (state, action) => {
+  return {
+    ...state,
+    [action.id]: action.value
+  }
+}

--- a/FrontEnd/src/util/storage.js
+++ b/FrontEnd/src/util/storage.js
@@ -1,0 +1,29 @@
+export function storage(storageType) {
+  return {
+    getItem: (key) => {
+      // 추후 JSON.parse() 메서드로 value 값을 파싱해서 가져와야 하는 경우
+      // 해당 key 값을 parseKeys 배열에 추가하면 됨
+      // ex) 배열이나 객체 형태 값이 들어오는 경우
+      const parseKeys = [];
+      const value = storageType.getItem(key);
+      if (parseKeys.includes(key)) {
+        return JSON.parse(value);
+      } else {
+        return value;
+      }
+    },
+    setItem: (key, value) => {
+      // 추후 storage에 저장하는 값들이 배열이나 객체인 경우 JSON.stringify() 메서드를 사용해야하므로
+      // 해당 key 값을 stringifyKeys 배열에 추가하면 됨
+      const stringifyKeys = [];
+      if (stringifyKeys.includes(key)) {
+        storageType.setItem(key, JSON.stringify(value));
+      } else {
+        storageType.setItem(key, value);
+      }
+    },
+    removeItem: (key) => {
+      storageType.removeItem(key);
+    }
+  }
+}


### PR DESCRIPTION
## Online Test Pull Request

## 규칙
* 리뷰어 전원의 approve가 필요합니다.
* 마지막 approve한 리뷰어가 merge 후 해당 브랜치를 삭제합니다.

<!-- 본인이 올린 PR에 대한 내용을 달아주세요 -->
## 내용
### 1. `LoginPage` 컴포넌트 간결하게 구성
- 현재 URL 주소 값에 따라 `로그인 페이지` 또는 `비밀번호 찾기` 페이지가 나오도록 구성

### 2. 로그인 페이지 기본 레이아웃 구성
- `아이디`, `비밀번호` 입력창 및 `아이디 저장` 버튼 구성

### 3. 비밀번호 찾기 페이지 기본 레이아웃 구성
- 아이디와 가입할 때 작성한 이메일 주소 입력 form 구성
- 추후 `비밀번호 찾기` 버튼을 누르면 작성한 이메일 주소로 임시 비밀번호 발급

### 4. `storage.js` util 함수 추가
- 추후 `localStorage`와 `sessionStorage`를 편하게 사용하기 위해 하나의 util 함수로 구성
- 사용 예시
```javascript
import { storage } from '../util/storage.js';

const id = 'user001';
storage(localStorage).setItem('saveId', id); // sessiongStorage도 동일하게 적용 가능
const saveId = storage(localStorage).getItem('saveId'); // sessiongStorage도 동일하게 적용 가능
console.log(saveId); // user001
```
- 객체나 배열 형태의 데이터는 `JSON.stringify()`, `JSON.parse()` 메서드를 이용해서 값을 저장하거나 가져와야 하므로 `storage.js`에 `parseKeys`, `stringifyKeys` 배열을 구성하여 해당 key 값으로 들어오는 것들은 `JSON` 메서드를 적용할 수 있도록 임시 구성(다양한 의견 교류를 통해서 더 좋은 방향이 있으면 개선해 나갈 예정)

### 5. `reducer` 함수 공통 `util` 함수로 구성 (2020-09-08 Update)
- `useReducer`에서 사용되는 `reducer` 함수가 공통적으로 사용되는 컴포넌트가 많아서 `util` 폴더 안에 하나의 공통 함수로 구성

<!-- PR을 올리며 아쉬운 부분이나 리뷰어의 
    도움이 필요한 부분을 남겨주세요 -->
## 의견
- ~ 한 부분 퍼포먼스가 좋지않을듯한데 더 좋은 코드가 있을까요?
    
<details><summary>리뷰어 도움말</summary>
<p>

> 리뷰 코멘트시 다음의 말머리를 사용해 주세요.
#### 머지 OK
  - [의견] - 더 나은 것으로 생각되는 코드가 있는 경우 제안
  - [질문] - 설명이 부족하거나 이 부분만으로는 이유를 알 수 없는 부분에 설명을 부탁
</p>
</details>