### PR TITLE
[FE-022] 시험 대기페이지 레이아웃 및 테스트 시작 버튼

### DIFF
--- a/FrontEnd/package-lock.json
+++ b/FrontEnd/package-lock.json
@@ -2469,6 +2469,14 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.10.1.tgz",
       "integrity": "sha512-zg7Hz2k5lI8kb7U32998pRRFin7zJlkfezGJjUc2heaD4Pw2wObakCDVzkKztTm/Ln7eiVvYsjqak0Ed4LkMDA=="
     },
+    "axios": {
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.20.0.tgz",
+      "integrity": "sha512-ANA4rr2BDcmmAQLOKft2fufrtuvlqR+cXNNinUmvfeSNCOF98PZL+7M/v1zIdGo7OLjEA9J2gXJL+j4zGsl0bA==",
+      "requires": {
+        "follow-redirects": "^1.10.0"
+      }
+    },
     "axobject-query": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.2.0.tgz",

--- a/FrontEnd/package.json
+++ b/FrontEnd/package.json
@@ -6,6 +6,7 @@
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.3.2",
     "@testing-library/user-event": "^7.1.2",
+    "axios": "^0.20.0",
     "react": "^16.13.1",
     "react-addons-css-transition-group": "^15.6.2",
     "react-dom": "^16.13.1",

--- a/FrontEnd/src/App.js
+++ b/FrontEnd/src/App.js
@@ -8,6 +8,7 @@ import MainPage from './pages/MainPage';
 import ExamPage from './pages/ExamPage';
 import TeacherPage from './pages/TeacherPage';
 import NotFoundPage from './pages/NotFoundPage';
+import ExamWaitingPage from './pages/ExamWaitingPage';
 import { Switch } from 'react-router';
 import { Route } from 'react-router-dom';
 
@@ -22,6 +23,7 @@ function App() {
           <Route path="/signup" render={() => <SignupPage />} />
           <Route path="/exam" render={() => <ExamPage />} />
           <Route path="/teacher" render={() => <TeacherPage />} />
+          <Route path="/examwait" render={()=> <ExamWaitingPage/>}/>
           <Route component={NotFoundPage} />
         </Switch>
       </main>

--- a/FrontEnd/src/components/Exam/waiting/ExamInfo.js
+++ b/FrontEnd/src/components/Exam/waiting/ExamInfo.js
@@ -1,0 +1,11 @@
+import React from 'react';
+
+const ExamInfo = () => {
+  return (
+    <div>
+      <h1>Exam info</h1>
+    </div>
+  );
+};
+
+export default ExamInfo;

--- a/FrontEnd/src/components/Exam/waiting/ExamNotice.js
+++ b/FrontEnd/src/components/Exam/waiting/ExamNotice.js
@@ -1,0 +1,15 @@
+import React from 'react';
+import './ExamWaiting.css'
+const ExamNotice = () => {
+  return (
+    <div className="examnotice">
+      <ol>
+        <li>테스트는 순서와 상관없이 문제를 풀 수 있습니다.</li>
+        <li>시험이 시작되면 멈출수 없으며, 주어진 시간 내로 문제를 풀어야 합니다.</li>
+        <li>테스트 중에 브라우저가 종료되어도 다시 테스트를 진행할 수 있습니다. 이때 임시저장 버튼을 누른 시점으로 복원됩니다.</li>
+      </ol>
+    </div>
+  );
+};
+
+export default ExamNotice;

--- a/FrontEnd/src/components/Exam/waiting/ExamWaiting.css
+++ b/FrontEnd/src/components/Exam/waiting/ExamWaiting.css
@@ -1,0 +1,33 @@
+.examwaiting-content {
+  margin : auto;
+  width: 60%;
+  margin-top: 2rem;
+  margin-bottom: 2rem;
+  padding: 2rem;
+  border: 1px solid black;
+  border-radius: 1%;
+}
+
+.title {
+  font-size: small;
+  padding-bottom: 1rem;
+}
+
+.examwaiting-section {
+  padding:1rem 0;
+}
+
+.examwaiting-section:first-child {
+  padding-bottom: 1rem;
+  padding-top: 0;
+}
+
+.examwaiting-section:last-child {
+  padding-top: 1rem;
+  padding-bottom: 0;
+}
+
+.examnotice > ol > li {
+  list-style: decimal inside;
+}
+

--- a/FrontEnd/src/components/Exam/waiting/ExamWaitingSection.js
+++ b/FrontEnd/src/components/Exam/waiting/ExamWaitingSection.js
@@ -1,0 +1,12 @@
+import React from 'react';
+
+const ExamWaitingSection = (props) => {
+  return (
+    <div className="examwaiting-section">
+      <p className="title gray">{props.title}</p>
+      {props.children}
+    </div>
+  );
+};
+
+export default ExamWaitingSection;

--- a/FrontEnd/src/components/Exam/waiting/StartExamButton.js
+++ b/FrontEnd/src/components/Exam/waiting/StartExamButton.js
@@ -1,0 +1,27 @@
+import React, { useEffect, useState } from 'react';
+import {timeDiff} from '../../../util/time'
+
+
+const StartExamButton = (props) => {
+  const propsDiffTime = props.diffTime
+  const [diffTime, setDiffTime ] = useState(propsDiffTime)
+  
+  useEffect(() => {
+    if (diffTime === 9999999) {
+      setDiffTime(props.diffTime)
+    }
+    else {
+      const timer = setInterval(() => {
+        setDiffTime(diffTime => diffTime - 1)
+      }, 1000)
+      return () => clearInterval(timer)
+    }
+  },[props.diffTime, diffTime])
+  return (
+    <div>
+      <button>{timeDiff(diffTime)}</button>
+    </div>
+  );
+};
+
+export default StartExamButton;

--- a/FrontEnd/src/pages/ExamWaitingPage.js
+++ b/FrontEnd/src/pages/ExamWaitingPage.js
@@ -1,0 +1,69 @@
+import React, { useReducer, useEffect } from 'react';
+import '../components/Exam/waiting/ExamWaiting.css'
+import ExamWaitingSection from '../components/Exam/waiting/ExamWaitingSection'
+import ExamInfo from '../components/Exam/waiting/ExamInfo'
+import ExamNotice from '../components/Exam/waiting/ExamNotice'
+import StartExamButton from '../components/Exam/waiting/StartExamButton'
+import axios from 'axios'
+
+const getExamInfo = () => {
+  const baseUrl = `http://221.158.91.249:5000/api/readytest?exam_id=${1}`
+  const headers = {
+    'access-token' : process.env.REACT_APP_TEMP_TOKEN,
+  }
+  return axios.get(baseUrl, {headers:headers})
+  .then(result => result)
+  .catch(error => console.log('error', error));
+}
+
+const reducer = (state, action) => {
+  const result = action.payload
+  return {
+    ...state,
+    diffTime: 40000,
+    id : result.data.id,
+    name : result.data.name,
+    endTime : result.data.endtime,
+    teacherName : result.data.teacher_name,
+    startTime : result.data.starttime,
+  }
+}
+
+const ExamWaitingPage = () => {
+  const [state, dispatch] = useReducer(reducer, {
+    diffTime: 9999999,
+    id : null,
+    name : null,
+    endTime : null,
+    teacherName : null,
+    startTime : null,
+  })
+
+  useEffect(() => {
+    async function aws() {
+      const result = await getExamInfo()
+      dispatch({payload: result})
+    }
+    aws()
+  },[])
+
+  const examContentList = [
+    {title : '시험시작 전 확인해주세요!', component: <ExamInfo/>},
+    {title: '테스트 주의사항', component: <ExamNotice/>},
+    {title: 'content3', component: <ExamInfo/>},
+  ]
+  return (
+    <div className="examwaiting-wrap">
+      <StartExamButton diffTime={state.diffTime}/>
+      <div className="examwaiting-content">
+        {examContentList.map((content, i) => {
+          return (<ExamWaitingSection key={i} title={content.title}>
+            {content.component}
+          </ExamWaitingSection>)
+        })}
+      </div>
+    </div>
+  );
+};
+
+export default ExamWaitingPage;

--- a/FrontEnd/src/util/time.js
+++ b/FrontEnd/src/util/time.js
@@ -4,10 +4,10 @@ export const timeDiff = (sec) => {
   const h = parseInt((sec/60/60)%24)
   const d = parseInt((sec/60/60/24))
   let diff = ''
-  if (d) {diff += `${d}일 `}
-  if (h) {diff += `${h}시간 `}
-  if (m) {diff += `${m}분 `} 
-  if (!d && s) {diff += `${s}초`}
+  if (d) {diff += `${d}`.padStart(2, '0') + '일 '}
+  diff += `${h}`.padStart(2, '0') + '시간 '
+  diff += `${m}`.padStart(2, '0') + '분'
+  if (!d) {diff += ' ' + `${s}`.padStart(2, '0') + '초'}
   return diff
 }
 export const timeToString = (time) => {


### PR DESCRIPTION
## Online Test Pull Request

## 규칙
* 리뷰어 전원의 approve가 필요합니다.
* 마지막 approve한 리뷰어가 merge 후 해당 브랜치를 삭제합니다.
### 1. 시험 대기 페이지 레이아웃
시험 대기 페이지 레이아웃 설정
### 2. 시험 대기 페이지 테스트 시작 버튼
- 버튼 내에 시간 감소
- 서버 시간과 시작시간을 기준으로 감소
- 서버 시간은 BE 서버 처리 후 다시 수정할 예정입니다.
### 3. Time.js 수정
- 함수 Timediff
 - 출력 값 "00시00분" => "00일00시00분" or "00시00분00초" 로 수정