### PR TITLE
[FE-024] 시험 응시 페이지 레이아웃 구성

### DIFF
--- a/FrontEnd/src/api/modules/tryout.js
+++ b/FrontEnd/src/api/modules/tryout.js
@@ -1,0 +1,6 @@
+import instance from '../index';
+
+// fetcth specific exam API
+export function fetchTryout(examId) {
+  return instance.get(`starttest?exam_id=${examId}`);
+}

--- a/FrontEnd/src/assets/json/tempExam.json
+++ b/FrontEnd/src/assets/json/tempExam.json
@@ -1,0 +1,78 @@
+{
+  "question": [
+    {
+      "id": 15,
+      "content": "test_content",
+      "description": "test_description",
+      "commentary": null,
+      "type": true,
+      "writer_id": 0,
+      "score": 5,
+      "examples": [
+        {
+          "id": 19,
+          "question_id": 0,
+          "content": "test_example",
+          "correct": null
+        },
+        {
+          "id": 20,
+          "question_id": 0,
+          "content": "test_example2",
+          "correct": null
+        },
+        {
+          "id": 21,
+          "question_id": 0,
+          "content": "test_example3",
+          "correct": null
+        }
+      ]
+    },
+    {
+      "id": 16,
+      "content": "문제 제목",
+      "description": "해설",
+      "commentary": null,
+      "type": true,
+      "writer_id": 0,
+      "score": 5,
+      "examples": []
+    },
+    {
+      "id": 17,
+      "content": "문제 제목",
+      "description": "해설",
+      "commentary": null,
+      "type": true,
+      "writer_id": 0,
+      "score": 8,
+      "examples": [
+        {
+          "id": 27,
+          "question_id": 0,
+          "content": "보기1",
+          "correct": null
+        },
+        {
+          "id": 28,
+          "question_id": 0,
+          "content": "보기2",
+          "correct": null
+        },
+        {
+          "id": 29,
+          "question_id": 0,
+          "content": "보기3",
+          "correct": null
+        },
+        {
+          "id": 30,
+          "question_id": 0,
+          "content": "보기4",
+          "correct": null
+        }
+      ]
+    }
+  ]
+}

--- a/FrontEnd/src/components/Tryout/Tryout.css
+++ b/FrontEnd/src/components/Tryout/Tryout.css
@@ -1,0 +1,28 @@
+.tryout {
+  display: flex;
+  padding: 1rem;
+}
+
+.tryout .tryout-question {
+  flex-grow: 1;
+  padding-right: 1rem;
+}
+
+.tryout .tryout-sidebar {
+  width: 220px;
+  padding-left: 1rem;
+  text-align: center;
+}
+
+.tryout .tryout-sidebar > button {
+  width: 100%;
+}
+
+.tryout .tryout-sidebar-box-style {
+  font-size: 1.2rem;
+  font-weight: 600;
+  padding: 0.75rem 0;
+  margin-bottom: 1.25rem;
+  border: 1px solid var(--beige);
+  border-radius: 10px;
+}

--- a/FrontEnd/src/components/Tryout/Tryout.js
+++ b/FrontEnd/src/components/Tryout/Tryout.js
@@ -1,11 +1,78 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+// import { fetchTryout } from '../../api/modules/tryout';
+import { withRouter } from 'react-router';
+import tempTryout from '../../assets/json/tempExam.json';
+import './Tryout.css';
+import TryoutQuestion from './TryoutQuestion';
+import TryoutTimer from './TryoutTimer';
+import TryoutRemainQuestion from './TryoutRemainQuestion';
+import TryoutQuestionButtons from './TryoutQuestionButtons';
 
-const Tryout = () => {
+// 임시 데이터로 작업(추후 삭제 예정)
+const tempData = tempTryout.question;
+
+const TryoutHeader = ({ location, history }) => {
+  const [tryout, setTryout] = useState(null);
+  const [nowQuestionNumber, setNowQuestionNumber] = useState(0);
+  const [myAnswer, setMyAnswer] = useState(null); // 내가 작성한 정답
+  const [error, setError] = useState(true);
+  const query = new URLSearchParams(location.search);
+  const token = query.get('token');
+
+  // const fetchSpecificTryout = async () => {
+  //   return await fetchTryout(9);
+  // }
+
+  useEffect(() => {
+    if (!token) {
+      history.push('/');
+      return
+    }
+
+    // 임시 데이터로 작업(추후 삭제 예정)
+    setError(false);
+    setTryout(tempData);
+    const initMyAnswer = Array(tempData.length).fill(null);
+    setMyAnswer(initMyAnswer);
+
+    // 실제 시험 정보 가져오는 로직
+    // (나중에 주석 풀어서 할 것, 지금은 assets/json 안에 있는 임시 데이터로 작업)
+    // const fetchTryoutData = async () => {
+    //   try {
+    //     const { data } = await fetchSpecificTryout();
+    //     setTryout(data.question);
+    //     setMyAnswer(Array(data.question.length).fill(null));
+    //     setError(false);
+    //   } catch (error) {
+    //     setTryout(error);
+    //   }
+    // }
+
+    // fetchTryoutData();
+  }, []);
+
+  const onChangeNowQuestionNumber = e => {
+    const selectedNumber = e.target.innerText;
+    setNowQuestionNumber(Number(selectedNumber - 1));
+  }
+
+  if (error) {
+    return <p>예기치 못한 에러가 발생했습니다. 다시 접속해주세요.</p>
+  }
+
   return (
-    <div>
-      본 시험 응시 페이지
+    <div className="tryout">
+      <section className="tryout-question">
+        <TryoutQuestion nowQuestion={tryout[nowQuestionNumber]} nowQuestionNumber={nowQuestionNumber} />
+      </section>
+      <section className="tryout-sidebar">
+        <TryoutTimer />
+        <TryoutRemainQuestion myAnswer={myAnswer} />
+        <TryoutQuestionButtons myAnswer={myAnswer} onChangeNowQuestionNumber={onChangeNowQuestionNumber} />
+        <button className="btn">최종 답안 제출</button>
+      </section>
     </div>
   );
 };
 
-export default Tryout;
+export default withRouter(TryoutHeader);

--- a/FrontEnd/src/components/Tryout/TryoutQuestion.css
+++ b/FrontEnd/src/components/Tryout/TryoutQuestion.css
@@ -1,0 +1,7 @@
+.tryout-question-header {
+  font-size: 1.2rem;
+  font-weight: 600;
+  padding-bottom: 0.5rem;
+  margin-bottom: 1rem;
+  border-bottom: 1px solid var(--light-gray);
+}

--- a/FrontEnd/src/components/Tryout/TryoutQuestion.js
+++ b/FrontEnd/src/components/Tryout/TryoutQuestion.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import './TryoutQuestion.css';
+
+const TryoutQuestion = ({ nowQuestion, nowQuestionNumber }) => {
+  return (
+    <>
+      <div className="tryout-question-header">
+        Q{nowQuestionNumber + 1}. {nowQuestion.content} ({nowQuestion.score}점)
+      </div>
+      <div className="tryout-question-examples">
+        {nowQuestion.examples.map(example => {
+          return <p key={example.id}>{example.content}</p>
+        })}
+      </div>
+    </>
+  );
+};
+
+export default TryoutQuestion;

--- a/FrontEnd/src/components/Tryout/TryoutQuestionButtons.css
+++ b/FrontEnd/src/components/Tryout/TryoutQuestionButtons.css
@@ -1,0 +1,16 @@
+.tryout-question-buttons {
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  gap: 0.5rem;
+  padding-bottom: 1.25rem
+}
+
+.tryout-question-buttons .tryout-question-button {
+  background-color: var(--beige);
+  box-shadow: var(--box-shadow);
+  padding: 0.2rem 0;
+}
+
+.tryout-question-buttons .tryout-question-button:hover {
+  cursor: pointer;
+}

--- a/FrontEnd/src/components/Tryout/TryoutQuestionButtons.js
+++ b/FrontEnd/src/components/Tryout/TryoutQuestionButtons.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import './TryoutQuestionButtons.css';
+
+const TryoutQuestionButtons = ({ myAnswer, onChangeNowQuestionNumber }) => {
+  return (
+    <div className="tryout-question-buttons">
+      {myAnswer.map((answer, i) => {
+        return <div className="tryout-question-button" key={i} onClick={onChangeNowQuestionNumber}>{i + 1}</div>
+      })}
+    </div>
+  );
+};
+
+export default TryoutQuestionButtons;

--- a/FrontEnd/src/components/Tryout/TryoutRemainQuestion.css
+++ b/FrontEnd/src/components/Tryout/TryoutRemainQuestion.css
@@ -1,0 +1,4 @@
+.tryout-remain-question-title {
+  font-size: 1.05rem;
+  padding-bottom: 0.5rem;
+}

--- a/FrontEnd/src/components/Tryout/TryoutRemainQuestion.js
+++ b/FrontEnd/src/components/Tryout/TryoutRemainQuestion.js
@@ -1,0 +1,15 @@
+import React from 'react';
+import './TryoutRemainQuestion.css';
+
+const TryoutRemainQuestion = ({ myAnswer }) => {
+  return (
+    <div className="tryout-sidebar-box-style">
+      <div className="tryout-remain-question-title">
+        <i className="fas fa-question" /> 해결한 문제 수
+      </div>
+      {myAnswer.filter(answer => answer).length} / {myAnswer.length}
+    </div>
+  );
+};
+
+export default TryoutRemainQuestion;

--- a/FrontEnd/src/components/Tryout/TryoutTimer.js
+++ b/FrontEnd/src/components/Tryout/TryoutTimer.js
@@ -1,0 +1,11 @@
+import React from 'react';
+
+const TryoutTimer = () => {
+  return (
+    <div className="tryout-sidebar-box-style">
+      <i className="far fa-clock" /> 00시간 00분 00초
+    </div>
+  );
+};
+
+export default TryoutTimer;

--- a/FrontEnd/src/pages/TryoutPage.js
+++ b/FrontEnd/src/pages/TryoutPage.js
@@ -10,7 +10,7 @@ import { Switch, withRouter } from 'react-router';
 import { Route } from 'react-router-dom';
 
 const TryoutPage = ({ location }) => {
-  const authenticationStatus = location.pathname.split('/').length == 4 && !location.pathname.includes('finish')
+  const authenticationStatus = location.pathname.split('/').length === 4 && !location.pathname.includes('finish');
 
   return (
     <>

--- a/FrontEnd/src/store/tryout.js
+++ b/FrontEnd/src/store/tryout.js
@@ -23,7 +23,7 @@ const tryoutInfo = handleActions(
     [SAVE_AUTH_INFO]: (state, { payload }) => ({
       ...state,
       examInfo: payload.examInfo,
-      studentInfo: payload.examInfo
+      studentInfo: payload.studentInfo
     }),
     [REMOVE_AUTH_INFO]: () => ({
       auth: false,


### PR DESCRIPTION
## Online Test Pull Request

## 규칙
* 리뷰어 전원의 approve가 필요합니다.
* 마지막 approve한 리뷰어가 merge 후 해당 브랜치를 삭제합니다.

<!-- 본인이 올린 PR에 대한 내용을 달아주세요 -->
## 내용
### 1. 학생 시험 응시 페이지 레이아웃 구성
![캡처](https://user-images.githubusercontent.com/52685250/95839094-8b0ead00-0d7d-11eb-84d5-e4559b5b68ff.PNG)
- 좌측에는 해당 문제를, 우측에는 남은 시간, 해결한 문제수, 문제 번호 이동과 같은 부속적인 것들을 모아서 구성
- 현재는 `assets/json/tempExam.json`의 임시 데이터를 가져와서 구성했지만 추후 주석 처리되어 있는 실제 시험 정보 가져오는 로직을 사용해서 시험 페이지 구성할 예정