### PR TITLE
[Hotfix-003] 생성 및 수정에서 user_id 입력하지 않아도 되도록 수정, 테스팅 파일 변경, 서버시간 타임존 변경

### DIFF
--- a/BackEnd/src/main/java/com/onlinetest/backend/controller/ExamController.java
+++ b/BackEnd/src/main/java/com/onlinetest/backend/controller/ExamController.java
@@ -66,11 +66,9 @@ public class ExamController {
     @ResponseBody
     public ResponseEntity<ExamSwagger> createExam(@RequestBody ExamQuestionsSwagger examQuestion){
         int user_id = jwtservice.getId();
+        examQuestion.setTeacher_id(user_id);
         // 검증
-        if (examQuestion.getTeacher_id() != user_id){
-            return new ResponseEntity<ExamSwagger>(new ExamSwagger(), HttpStatus.UNAUTHORIZED);
-        }
-        else if (examQuestion.getName() == null || examQuestion.getStarttime() == null || examQuestion.getEndtime() == null){
+        if (examQuestion.getName() == null || examQuestion.getStarttime() == null || examQuestion.getEndtime() == null){
             return new ResponseEntity<ExamSwagger>(new ExamSwagger(), HttpStatus.BAD_REQUEST);
         }
         else if (examQuestion.getStarttime().isAfter(examQuestion.getEndtime())){
@@ -110,21 +108,25 @@ public class ExamController {
     @ResponseBody
     public ResponseEntity<ExamSwagger> updateExam(@RequestBody ExamQuestionsSwagger examQuestion) {
         int user_id = jwtservice.getId();
+        int exam_id = examQuestion.getId();
+        examQuestion.setTeacher_id(user_id);
         // 검증
-        if (examQuestion.getTeacher_id() != user_id){
-            return new ResponseEntity<ExamSwagger>(new ExamSwagger(), HttpStatus.UNAUTHORIZED);
-        }
-        else if (examQuestion.getName() == null || examQuestion.getQuestions() == null
+        if (examQuestion.getName() == null || examQuestion.getQuestions() == null
                 || examQuestion.getStarttime() == null || examQuestion.getEndtime() == null){
             return new ResponseEntity<ExamSwagger>(new ExamSwagger(), HttpStatus.BAD_REQUEST);
         }
         else if (examQuestion.getStarttime().isAfter(examQuestion.getEndtime())){
-            return new ResponseEntity<ExamSwagger>(new ExamSwagger(), HttpStatus.BAD_REQUEST);
+            return new ResponseEntity<ExamSwagger>(HttpStatus.BAD_REQUEST);
         }
-        int exam_id = examQuestion.getId();
-        if (examService.getExamById(exam_id) == null){
-            return new ResponseEntity<ExamSwagger>(new ExamSwagger(), HttpStatus.BAD_REQUEST);
+        ExamSwagger origin = examService.getExamById(exam_id);
+        if (origin == null){
+            return new ResponseEntity<ExamSwagger>(HttpStatus.BAD_REQUEST);
         }
+        else if (origin.getTeacher_id() != user_id){
+            return new ResponseEntity<ExamSwagger>(HttpStatus.UNAUTHORIZED);
+        }
+
+
 
         List<QuestionExam> questionExamTable = examQuestion.getQuestions();
         for (QuestionExam questionExam: questionExamTable) {

--- a/BackEnd/src/main/java/com/onlinetest/backend/controller/QuestionController.java
+++ b/BackEnd/src/main/java/com/onlinetest/backend/controller/QuestionController.java
@@ -62,15 +62,13 @@ public class QuestionController {
     @ResponseBody
     public ResponseEntity<QuestionList> addQuestions(@RequestBody QuestionList questionList){
         int user_id = jwtservice.getId();
+
         List<Question> result = new ArrayList<>();
         for (Question question: questionList.getQuestion()) {
-            if (question.getWriter_id() != user_id){
-                return new ResponseEntity<QuestionList>(new QuestionList(), HttpStatus.UNAUTHORIZED);
-            }
-            else if (question.getContent() == null || question.getExamples() == null){
+            question.setWriter_id(user_id);
+            if (question.getContent() == null || question.getExamples() == null){
                 return new ResponseEntity<QuestionList>(new QuestionList(), HttpStatus.BAD_REQUEST);
             }
-
         }
         for (Question question: questionList.getQuestion()) {
             questionService.createQuestion(question);
@@ -91,11 +89,8 @@ public class QuestionController {
     @ResponseBody
     public ResponseEntity<Question> addQuestion(@RequestBody Question question){
         int user_id = jwtservice.getId();
-
-        if (question.getWriter_id() != user_id){
-            return new ResponseEntity<Question>(new Question(), HttpStatus.UNAUTHORIZED);
-        }
-        else if (question.getContent() == null || question.getExamples() == null){
+        question.setWriter_id(user_id);
+        if (question.getContent() == null || question.getExamples() == null){
             return new ResponseEntity<Question>(new Question(), HttpStatus.BAD_REQUEST);
         }
         questionService.createQuestion(question);
@@ -115,18 +110,18 @@ public class QuestionController {
     public ResponseEntity<Question> updateQuestion(@RequestBody Question question) {
         int user_id = jwtservice.getId();
         int q_id = question.getId();
-        Map<String, Object> resultMap = new HashMap<>();
+
+        question.setWriter_id(user_id);
         Question origin = questionService.getQuestionById(q_id);
-        if (origin == null || origin.getWriter_id() != user_id){
-            return new ResponseEntity<Question>(new Question(), HttpStatus.BAD_REQUEST);
+        if (origin == null){
+            return new ResponseEntity<Question>(HttpStatus.BAD_REQUEST);
         }
-        else if (question.getWriter_id() != user_id){
-            return new ResponseEntity<Question>(new Question(), HttpStatus.UNAUTHORIZED);
+        else if (origin.getWriter_id() != user_id){
+            return new ResponseEntity<Question>(HttpStatus.UNAUTHORIZED);
         }
         else if (question.getContent() == null || question.getExamples() == null){
-            return new ResponseEntity<Question>(new Question(), HttpStatus.BAD_REQUEST);
+            return new ResponseEntity<Question>(HttpStatus.BAD_REQUEST);
         }
-
 
         List<Example>examples = question.getExamples();
         questionService.deleteExamples(q_id);
@@ -150,13 +145,9 @@ public class QuestionController {
         if (question == null){
             return new ResponseEntity<Boolean>(false, HttpStatus.NOT_FOUND);
         }
-        else if (question.getWriter_id() != user_id){
-            return new ResponseEntity<Boolean>(false, HttpStatus.UNAUTHORIZED);
-        }
 
         questionService.deleteExamples(id);
         questionService.deleteQuestion(id);
-
         return new ResponseEntity<Boolean>(true, HttpStatus.OK);
     }
 }

--- a/BackEnd/src/main/java/com/onlinetest/backend/controller/UserController.java
+++ b/BackEnd/src/main/java/com/onlinetest/backend/controller/UserController.java
@@ -1,6 +1,7 @@
 package com.onlinetest.backend.controller;
 
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
@@ -168,7 +169,7 @@ public class UserController {
 
 	@RequestMapping(value = "/time", method = RequestMethod.GET)
 	public ResponseEntity<LocalDateTime> getLocalTime() throws Exception {
-		LocalDateTime now = LocalDateTime.now();
+		LocalDateTime now = LocalDateTime.now(ZoneId.of("Asia/Seoul"));
 		return new ResponseEntity<LocalDateTime> (now, HttpStatus.OK);
 	}
 

--- a/BackEnd/src/test/java/com/onlinetest/backend/controllerTest/ExamControllerTest.java
+++ b/BackEnd/src/test/java/com/onlinetest/backend/controllerTest/ExamControllerTest.java
@@ -156,7 +156,7 @@ public class ExamControllerTest {
         LocalDateTime endtime = LocalDateTime.of(2020, 10, 6, 15,0,0);
 
         int teacher_id = 4;
-        int wrong_teacher_id = 2;
+
 
         int question_id = 74;
         int wrong_question_id1 = 18;
@@ -166,7 +166,7 @@ public class ExamControllerTest {
         // 정상 시험
         Exam exam = new Exam(name, starttime, endtime, teacher_id);
         // 접속한 사람과 시험 내는사람이 다른 경우
-        Exam wrong_exam1 = new Exam(name, starttime, endtime, wrong_teacher_id);
+
         // 시험의 이름이 없는 경우
         Exam wrong_exam2 = new Exam(starttime, endtime, teacher_id);
         // 시험의 시작시간이 없는 경우
@@ -199,9 +199,8 @@ public class ExamControllerTest {
         // 문제가 없는 케이스
         ExamQuestionsSwagger wrong_case3 = new ExamQuestionsSwagger(exam, wrong_questionExamTable3);
         HttpEntity<ExamQuestionsSwagger> wrong_httpEntity3 = new HttpEntity<>(wrong_case3, headers);
-        // 접속한 사람과 시험 내는사람이 다른 경우
-        ExamQuestionsSwagger wrong_case4 = new ExamQuestionsSwagger(wrong_exam1, questionExamTable);
-        HttpEntity<ExamQuestionsSwagger> wrong_httpEntity4 = new HttpEntity<>(wrong_case4, headers);
+
+
         // 시험의 이름이 없는 경우
         ExamQuestionsSwagger wrong_case5 = new ExamQuestionsSwagger(wrong_exam2, questionExamTable);
         HttpEntity<ExamQuestionsSwagger> wrong_httpEntity5 = new HttpEntity<>(wrong_case5, headers);
@@ -218,7 +217,7 @@ public class ExamControllerTest {
         ResponseEntity<ExamSwagger> wrongResponseEntity1 = restTemplate.exchange(uri, HttpMethod.POST, wrong_httpEntity1, ExamSwagger.class);
         ResponseEntity<ExamSwagger> wrongResponseEntity2 = restTemplate.exchange(uri, HttpMethod.POST, wrong_httpEntity2, ExamSwagger.class);
         ResponseEntity<ExamSwagger> wrongResponseEntity3 = restTemplate.exchange(uri, HttpMethod.POST, wrong_httpEntity3, ExamSwagger.class);
-        ResponseEntity<ExamSwagger> wrongResponseEntity4 = restTemplate.exchange(uri, HttpMethod.POST, wrong_httpEntity4, ExamSwagger.class);
+
         ResponseEntity<ExamSwagger> wrongResponseEntity5 = restTemplate.exchange(uri, HttpMethod.POST, wrong_httpEntity5, ExamSwagger.class);
         ResponseEntity<ExamSwagger> wrongResponseEntity6 = restTemplate.exchange(uri, HttpMethod.POST, wrong_httpEntity6, ExamSwagger.class);
         ResponseEntity<ExamSwagger> wrongResponseEntity7 = restTemplate.exchange(uri, HttpMethod.POST, wrong_httpEntity7, ExamSwagger.class);
@@ -227,7 +226,6 @@ public class ExamControllerTest {
         assertThat(wrongResponseEntity1.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
         assertThat(wrongResponseEntity2.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
         assertThat(wrongResponseEntity3.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
-        assertThat(wrongResponseEntity4.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
         assertThat(wrongResponseEntity5.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
         assertThat(wrongResponseEntity6.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
         assertThat(wrongResponseEntity7.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
@@ -279,8 +277,7 @@ public class ExamControllerTest {
 
         // 정상 시험
         Exam exam = new Exam(exam_id, name, starttime, endtime, teacher_id);
-        // 접속한 사람과 시험 내는사람이 다른 경우
-        Exam wrong_exam1 = new Exam(exam_id, name, starttime, endtime, wrong_teacher_id);
+
         // 시험의 이름이 없는 경우
         Exam wrong_exam2 = new Exam(exam_id, starttime, endtime, teacher_id);
         // 시험의 시작시간이 없는 경우
@@ -315,9 +312,7 @@ public class ExamControllerTest {
         // 문제가 없는 케이스
         ExamQuestionsSwagger wrong_case3 = new ExamQuestionsSwagger(exam, wrong_questionExamTable3);
         HttpEntity<ExamQuestionsSwagger> wrong_httpEntity3 = new HttpEntity<>(wrong_case3, headers);
-        // 접속한 사람과 시험 내는사람이 다른 경우
-        ExamQuestionsSwagger wrong_case4 = new ExamQuestionsSwagger(wrong_exam1, questionExamTable);
-        HttpEntity<ExamQuestionsSwagger> wrong_httpEntity4 = new HttpEntity<>(wrong_case4, headers);
+
         // 시험의 이름이 없는 경우
         ExamQuestionsSwagger wrong_case5 = new ExamQuestionsSwagger(wrong_exam2, questionExamTable);
         HttpEntity<ExamQuestionsSwagger> wrong_httpEntity5 = new HttpEntity<>(wrong_case5, headers);
@@ -335,7 +330,7 @@ public class ExamControllerTest {
         ResponseEntity<ExamSwagger> wrongResponseEntity1 = restTemplate.exchange(uri, HttpMethod.PUT, wrong_httpEntity1, ExamSwagger.class);
         ResponseEntity<ExamSwagger> wrongResponseEntity2 = restTemplate.exchange(uri, HttpMethod.PUT, wrong_httpEntity2, ExamSwagger.class);
         ResponseEntity<ExamSwagger> wrongResponseEntity3 = restTemplate.exchange(uri, HttpMethod.PUT, wrong_httpEntity3, ExamSwagger.class);
-        ResponseEntity<ExamSwagger> wrongResponseEntity4 = restTemplate.exchange(uri, HttpMethod.PUT, wrong_httpEntity4, ExamSwagger.class);
+
         ResponseEntity<ExamSwagger> wrongResponseEntity5 = restTemplate.exchange(uri, HttpMethod.PUT, wrong_httpEntity5, ExamSwagger.class);
         ResponseEntity<ExamSwagger> wrongResponseEntity6 = restTemplate.exchange(uri, HttpMethod.PUT, wrong_httpEntity6, ExamSwagger.class);
         ResponseEntity<ExamSwagger> wrongResponseEntity7 = restTemplate.exchange(uri, HttpMethod.PUT, wrong_httpEntity7, ExamSwagger.class);
@@ -346,7 +341,7 @@ public class ExamControllerTest {
         assertThat(wrongResponseEntity1.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
         assertThat(wrongResponseEntity2.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
         assertThat(wrongResponseEntity3.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
-        assertThat(wrongResponseEntity4.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+
         assertThat(wrongResponseEntity5.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
         assertThat(wrongResponseEntity6.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
         assertThat(wrongResponseEntity7.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);

--- a/BackEnd/src/test/java/com/onlinetest/backend/controllerTest/QuestionControllerTest.java
+++ b/BackEnd/src/test/java/com/onlinetest/backend/controllerTest/QuestionControllerTest.java
@@ -150,7 +150,6 @@ public class QuestionControllerTest {
         String description = "문제 설명";
         String commentary = "문제 해설";
         boolean type = true;
-        int wrong_user_id = 2;
         List<Example> exampleList = new ArrayList<>();
         exampleList.add(new Example("보기1", false));
         exampleList.add(new Example("보기2", false));
@@ -164,18 +163,13 @@ public class QuestionControllerTest {
         // 보기 없을 때
         Question wrongQuestion1 = new Question(content, description, commentary, type, user_id);
         HttpEntity<Question> wrong_httpEntity1 = new HttpEntity<>(wrongQuestion1, headers);
-        // 작성자가 잘못 되었을 때
-        Question wrongQuestion2 = new Question(content, description, commentary, type, wrong_user_id, exampleList);
-        HttpEntity<Question> wrong_httpEntity2 = new HttpEntity<>(wrongQuestion2, headers);
 
         // when
         ResponseEntity<Question> responseEntity = restTemplate.exchange(uri, HttpMethod.POST, httpEntity, Question.class);
         ResponseEntity<Question> wrongResponseEntity1 = restTemplate.exchange(uri, HttpMethod.POST, wrong_httpEntity1, Question.class);
-        ResponseEntity<Question> wrongResponseEntity2 = restTemplate.exchange(uri, HttpMethod.POST, wrong_httpEntity2, Question.class);
 
         // then
         assertThat(wrongResponseEntity1.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
-        assertThat(wrongResponseEntity2.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
         assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.OK);
         List<Question> questionList = questionDao.getQuestions(user_id).getQuestion();
         Question question1 = questionList.get(questionList.size()-1);
@@ -226,9 +220,7 @@ public class QuestionControllerTest {
         // 보기 없을 때
         Question wrongQuestion1 = new Question(question_id, content, description, commentary, type, user_id);
         HttpEntity<Question> wrong_httpEntity1 = new HttpEntity<>(wrongQuestion1, headers);
-        // 작성자가 잘못 되었을 때
-        Question wrongQuestion2 = new Question(question_id, content, description, commentary, type, wrong_user_id, exampleList);
-        HttpEntity<Question> wrong_httpEntity2 = new HttpEntity<>(wrongQuestion2, headers);
+
         // pk가 잘못 들어 갔을 때
         Question wrongQuestion3 = new Question(wrong_question_id, content, description, commentary, type, user_id, exampleList);
         HttpEntity<Question> wrong_httpEntity3 = new HttpEntity<>(wrongQuestion3, headers);
@@ -236,12 +228,10 @@ public class QuestionControllerTest {
         // when
         ResponseEntity<Question> responseEntity = restTemplate.exchange(uri, HttpMethod.PUT, httpEntity, Question.class);
         ResponseEntity<Question> wrongResponseEntity1 = restTemplate.exchange(uri, HttpMethod.PUT, wrong_httpEntity1, Question.class);
-        ResponseEntity<Question> wrongResponseEntity2 = restTemplate.exchange(uri, HttpMethod.PUT, wrong_httpEntity2, Question.class);
         ResponseEntity<Question> wrongResponseEntity3 = restTemplate.exchange(uri, HttpMethod.PUT, wrong_httpEntity3, Question.class);
 
         // then
         assertThat(wrongResponseEntity1.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
-        assertThat(wrongResponseEntity2.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
         assertThat(wrongResponseEntity3.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
         assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.OK);
         Question question1 = questionDao.getQuestionById(question_id);


### PR DESCRIPTION
## Online Test Pull Request

## 규칙
* 리뷰어 전원의 approve가 필요합니다.
* 마지막 approve한 리뷰어가 merge 후 해당 브랜치를 삭제합니다.

<!-- 본인이 올린 PR에 대한 내용을 달아주세요 -->
## 내용
1.시험 컨트롤러
    > 시험 수정 및 생성 부분에서 teacher_id를 입력하지 않아도 로그인 정보기반으로 처리 하도록 변경
    
2. 문제 컨트롤러
    > 문제 수정 및 생성 부분에서 teacher_id를 입력하지 않아도 로그인 정보기반으로 처리 하도록 변경

3. 유저 컨트롤러
    > 서버시간 넘겨주는 부분에서 타임존 변경하여 한국시간 보내주도록 변경

4. 테스팅 파일
   > 시험 및 문제 컨트롤러 변경사항 반영

<!-- PR을 올리며 아쉬운 부분이나 리뷰어의 
    도움이 필요한 부분을 남겨주세요 -->
## 의견
- ~ 한 부분 퍼포먼스가 좋지않을듯한데 더 좋은 코드가 있을까요?
    
<details><summary>리뷰어 도움말</summary>
<p>

> 리뷰 코멘트시 다음의 말머리를 사용해 주세요.
#### 머지 OK
  - [의견] - 더 나은 것으로 생각되는 코드가 있는 경우 제안
  - [질문] - 설명이 부족하거나 이 부분만으로는 이유를 알 수 없는 부분에 설명을 부탁
</p>
</details>